### PR TITLE
Experiment metadata

### DIFF
--- a/annotation_tracker/web_client/panels/Experiments/experiments.pug
+++ b/annotation_tracker/web_client/panels/Experiments/experiments.pug
@@ -14,13 +14,16 @@ if !collapsed
   - attrs.class = 'in'
 .s-panel-content.collapse&attributes(attrs)
   .status
-    | Experiment #{experiment}, Task #{task} (#{running ? 'running' : 'suspended'})
+    if !complete
+      | Experiment: #{experiment}, Task: #{task} (#{running ? 'running' : 'suspended'})
+    else 
+      | Complete: go to the next Image
 
   .btn-group.h-experiment-control-buttons(role='group')
-    button.btn.btn-default.h-toggle-experiment(type='button', title='Toggle experiment')
+    button.btn.btn-default.h-toggle-experiment(type='button', disabled=complete title='Toggle experiment')
       if running
         span.icon-pause
       else
         span.icon-play
-    button.btn.btn-default.h-advance-task(type='button', title='Advance to next task')
+    button.btn.btn-default.h-advance-task(type='button', disabled=complete title='Advance to next task')
       span.icon-to-end

--- a/annotation_tracker/web_client/panels/Experiments/index.js
+++ b/annotation_tracker/web_client/panels/Experiments/index.js
@@ -36,11 +36,11 @@ const Experiments = Panel.extend({
     },
 
     processMetadata(metadata) {
-        if (metadata["Experiments"] !== undefined) {
+        if (metadata.experiments !== undefined) {
             // TODO: JSON Schema validation at some point to ensure we have all necessary data
             this.current_experiment  = 0;
             this.current_task = 0;    
-            this.experiments =  metadata["Experiments"];
+            this.experiments =  metadata.experiments;
             this.experiment = this.experiments[this.current_experiment].name;
             this.task = this.experiments[this.current_experiment].tasks[this.current_task];
             this.complete = false;

--- a/annotation_tracker/web_client/panels/Experiments/index.js
+++ b/annotation_tracker/web_client/panels/Experiments/index.js
@@ -1,6 +1,7 @@
 import _ from 'underscore';
 
 import Panel from '@girder/slicer_cli_web/views/Panel';
+import FolderModel from '@girder/core/models/FolderModel';
 
 import experiments from './experiments.pug';
 import activityLogger from '../../utility/activityLogger';
@@ -11,20 +12,49 @@ const Experiments = Panel.extend({
         'click .h-advance-task': 'advanceTask'
     }),
 
-    initialize() {
-        console.log('Experiments.initialize()');
-
+    initialize(spec) {
         this.running = false;
+        this.current_experiment  = 0;
+        this.current_task = 0;
         this.experiment = 0;
         this.task = 0;
-    },
+        this.complete = false;
+        this.meta = {}
 
+    
+
+    },
+    setFolderId(folderId) {
+        //fetch the metadata from the FolderID
+        const folderModel = new FolderModel();
+        folderModel.set({
+            _id: folderId
+        }).on('g:fetched', () => {
+            this.meta = folderModel.get('meta');
+            //Now we can process the metadata for tasks
+            this.processMetadata(this.meta);
+
+        }).on('g:error', () => {
+            console.log('error getting folder data');
+        }, this).fetch();
+    },
+    processMetadata(metadata) {
+        if (metadata["Experiments"]) {
+            this.experiments =  metadata["Experiments"];
+            this.experiment = this.experiments[this.current_experiment].name;
+            this.task = this.experiments[this.current_experiment].tasks[this.current_task];
+            this.complete = false;
+            this.render();
+        }
+    },
     render() {
+
         this.$el.html(experiments({
             id: 'experiments-panel',
             running: this.running,
             experiment: this.experiment,
-            task: this.task
+            task: this.task,
+            complete: this.complete
         }));
 
         return this;
@@ -37,10 +67,20 @@ const Experiments = Panel.extend({
     },
 
     advanceTask(evt) {
-        this.task += 1;
-        if (this.task > 3) {
-            this.experiment += 1;
-            this.task = 0;
+        this.current_task += 1;
+        if (!this.complete) {
+            if (this.current_task >= this.experiments[this.current_experiment].tasks.length) {
+                this.current_experiment += 1;
+                this.current_task = 0;
+            }
+            if (this.current_experiment >= this.experiments.length) {
+                this.current_experiment = 0;
+                this.current_task = 0;
+                this.complete = true;
+            } else {
+            this.task = this.experiments[this.current_experiment].tasks[this.current_task];
+            this.experiment = this.experiments[this.current_experiment].name;
+            }
         }
 
         activityLogger.log('experiment', {running: this.running, task: this.task, experiment: this.experiment, 'experimentAction': 'advanceTask'});

--- a/annotation_tracker/web_client/views/ImageView/index.js
+++ b/annotation_tracker/web_client/views/ImageView/index.js
@@ -10,8 +10,14 @@ wrap(ImageView, 'initialize', function (initialize) {
     });
 
     initialize.apply(this, _.rest(arguments));
+    // Fetch folderID to use for looking for experiments metadata
     this.listenTo(this.model, 'g:fetched', () => {
-        this.experiments.setFolderId(this.model.get('folderId'));
+        const folderId = this.model.get('folderId');
+        if (folderId !== undefined ) {
+            this.experiments.setFolderId(folderId);
+        } else {
+            console.warn(`ResourceId: ${this.model.get('_id')} doesn't have a folderId and can't be checked for experiments`);
+        }
     });
 });
 

--- a/annotation_tracker/web_client/views/ImageView/index.js
+++ b/annotation_tracker/web_client/views/ImageView/index.js
@@ -4,13 +4,15 @@ import _ from 'underscore';
 
 import Experiments from '../../panels/Experiments';
 import activityLogger from '../../utility/activityLogger';
-
 wrap(ImageView, 'initialize', function (initialize) {
     this.experiments = new Experiments({
-        parentView: this
+        parentView: this,
     });
 
     initialize.apply(this, _.rest(arguments));
+    this.listenTo(this.model, 'g:fetched', () => {
+        this.experiments.setFolderId(this.model.get('folderId'));
+    });
 });
 
 wrap(ImageView, 'render', function (render) {


### PR DESCRIPTION
resolves #7 

- Added in the capability to read the metadata of the parent folder for images and see if there is an `Experiments` object in there.
- That object is then used to cycle through experiments and tasks.
- I used that structure because it looked like the existing code was expecting multiple experiments with multiple tasks inside of each experiment.
- Not that great at backbone.js stuff but I couldn't get the `parentView.model` fetch event to connect inside of `Experiments/index.js` so I did it in the parent ImageView and passed it down

I didn't know exactly what was being looked for so I just tried to make in simple with the understanding that this will expand greatly in the future.

Video preview: https://github.com/arclamp/annotation-tracker/issues/7#issuecomment-783643537