### PR TITLE
Improve selector generation used in logging.

### DIFF
--- a/annotation_tracker/web_client/utility/activityLogger.js
+++ b/annotation_tracker/web_client/utility/activityLogger.js
@@ -15,9 +15,10 @@ import events from '@girder/histomicsui/events';
  */
 function targetSelector(elem) {
     elem = $(elem);
+    let classList = [...elem[0].classList];
     let selector = elem.prop('nodeName').toLowerCase() + (
         elem.attr('id') ? '#' + elem.attr('id') : '') + (
-        elem.attr('class') ? '.' + elem.attr('class').replaceAll(' ', '.') : '');
+        classList.length ? '.' + classList.join('.') : '');
     let parent = elem.parent();
     let siblings = parent.children(selector);
     if (siblings.length > 1) {


### PR DESCRIPTION
It turns out classes attributes can have arbitrary runs of spaces in them which could result in an invalid selector being stored.

I encountered an issue with this while working on another project that uses HistomicsUI (leaving the tracker on to exercise it).