### PR TITLE
Specify linux/amd64 as the docker platform.

### DIFF
--- a/devops/annotation_tracker/docker-compose.yml
+++ b/devops/annotation_tracker/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   girder:
     image: dsarchive/annotation_tracker
     build: ../..
+    platform: linux/amd64
     # Set CURRENT_UID to your user id (e.g., `CURRENT_UID=$(id -u):$(id -g)`)
     # so that local file assetstores and logs are owned by yourself.
     # user: ${CURRENT_UID}


### PR DESCRIPTION
I *think* this will prevent OSX from using aarch for the platform (and therefore M1 Macs will run in qemu mode), so that they can use our wheels.